### PR TITLE
Added firewall rules to manage traffic between two kind clusters

### DIFF
--- a/experimental/liqo-dev-fw-rules.sh
+++ b/experimental/liqo-dev-fw-rules.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+function get_subnet() {
+    local DOCKER_NETWORK="$1"
+    docker network inspect $DOCKER_NETWORK | jq '.[0].IPAM.Config[0].Subnet' | tr -d '"'
+}
+
+
+function block_api() {
+    local CLUSTER1="$1"
+    local CLUSTER2="$2"
+
+    sudo iptables -I LIQO-$CLUSTER1-$CLUSTER2 --src "$(get_subnet kind-liqo-$CLUSTER1)" --dst "$(get_subnet kind-liqo-$CLUSTER2)" -p tcp --dport 6443 -j DROP
+    sudo iptables -I LIQO-$CLUSTER2-$CLUSTER1 --src "$(get_subnet kind-liqo-$CLUSTER2)" --dst "$(get_subnet kind-liqo-$CLUSTER1)" -p tcp --dport 6443 -j DROP
+}
+
+function allow_api() {
+    local CLUSTER1="$1"
+    local CLUSTER2="$2"
+
+    sudo iptables -D LIQO-$CLUSTER1-$CLUSTER2 --src "$(get_subnet kind-liqo-$CLUSTER1)" --dst "$(get_subnet kind-liqo-$CLUSTER2)" -p tcp --dport 6443 -j DROP
+    sudo iptables -D LIQO-$CLUSTER2-$CLUSTER1 --src "$(get_subnet kind-liqo-$CLUSTER2)" --dst "$(get_subnet kind-liqo-$CLUSTER1)" -p tcp --dport 6443 -j DROP
+}
+
+function block_gateway() {
+    local CLUSTER1="$1"
+    local CLUSTER2="$2"
+
+    sudo iptables -I LIQO-$CLUSTER1-$CLUSTER2 --src "$(get_subnet kind-liqo-$CLUSTER1)" --dst "$(get_subnet kind-liqo-$CLUSTER2)" -p udp --dport 5871 -j DROP
+    sudo iptables -I LIQO-$CLUSTER2-$CLUSTER1 --src "$(get_subnet kind-liqo-$CLUSTER2)" --dst "$(get_subnet kind-liqo-$CLUSTER1)" -p udp --dport 5871 -j DROP
+}
+
+function allow_gateway() {
+    local CLUSTER1="$1"
+    local CLUSTER2="$2"
+
+    sudo iptables -D LIQO-$CLUSTER1-$CLUSTER2 --src "$(get_subnet kind-liqo-$CLUSTER1)" --dst "$(get_subnet kind-liqo-$CLUSTER2)" -p udp --dport 5871 -j DROP
+    sudo iptables -D LIQO-$CLUSTER2-$CLUSTER1 --src "$(get_subnet kind-liqo-$CLUSTER2)" --dst "$(get_subnet kind-liqo-$CLUSTER1)" -p udp --dport 5871 -j DROP
+}
+
+function block_auth() {
+    local CLUSTER1="$1"
+    local CLUSTER2="$2"
+
+    sudo iptables -I LIQO-$CLUSTER1-$CLUSTER2 --src "$(get_subnet kind-liqo-$CLUSTER1)" --dst "$(get_subnet kind-liqo-$CLUSTER2)" -p tcp --dport 443 -j DROP
+    sudo iptables -I LIQO-$CLUSTER2-$CLUSTER1 --src "$(get_subnet kind-liqo-$CLUSTER2)" --dst "$(get_subnet kind-liqo-$CLUSTER1)" -p tcp --dport 443 -j DROP
+}
+
+function allow_auth() {
+    local CLUSTER1="$1"
+    local CLUSTER2="$2"
+
+    sudo iptables -D LIQO-$CLUSTER1-$CLUSTER2 --src "$(get_subnet kind-liqo-$CLUSTER1)" --dst "$(get_subnet kind-liqo-$CLUSTER2)" -p tcp --dport 443 -j DROP
+    sudo iptables -D LIQO-$CLUSTER2-$CLUSTER1 --src "$(get_subnet kind-liqo-$CLUSTER2)" --dst "$(get_subnet kind-liqo-$CLUSTER1)" -p tcp --dport 443 -j DROP
+}
+
+function block_all() {
+    sudo iptables -I FORWARD -j DOCKER-KIND-LIQO-TRAFFIC
+}
+
+function allow_all() {
+    local CLUSTER1="$1"
+    local CLUSTER2="$2"
+
+    sudo iptables -D FORWARD -j DOCKER-KIND-LIQO-TRAFFIC
+    # Delete also possible rules previuosly created
+    allow_api $CLUSTER1 $CLUSTER2
+    allow_gateway $CLUSTER1 $CLUSTER2
+    allow_auth $CLUSTER1 $CLUSTER2
+    
+}

--- a/experimental/liqo-dev-fw-rules.sh
+++ b/experimental/liqo-dev-fw-rules.sh
@@ -55,14 +55,14 @@ function allow_auth() {
 }
 
 function block_all() {
-    sudo iptables -I FORWARD -j DOCKER-KIND-LIQO-TRAFFIC
+    sudo iptables -D FORWARD -j DOCKER-KIND-LIQO-TRAFFIC
 }
 
 function allow_all() {
     local CLUSTER1="$1"
     local CLUSTER2="$2"
 
-    sudo iptables -D FORWARD -j DOCKER-KIND-LIQO-TRAFFIC
+    sudo iptables -I FORWARD -j DOCKER-KIND-LIQO-TRAFFIC
     # Delete also possible rules previuosly created
     allow_api $CLUSTER1 $CLUSTER2
     allow_gateway $CLUSTER1 $CLUSTER2

--- a/experimental/liqo-dev-traffic.sh
+++ b/experimental/liqo-dev-traffic.sh
@@ -11,6 +11,39 @@
 # sudo iptables -I LIQO-cluster1-cluster2 -p tcp --dport 6443 -j DROP
 # sudo iptables -D LIQO-cluster1-cluster2 -p tcp --dport 6443 -j DROP
 
+# function get_subnet() {
+#     local DOCKER_NETWORK="$1"
+#     docker network inspect $DOCKER_NETWORK | jq '.[0].IPAM.Config[0].Subnet' | tr -d '"'
+# }
+
+# KUBERNETES API SERVER
+# Block connectivity
+# sudo iptables -I LIQO-cluster1-cluster2 --src "$(get_subnet kind-liqo-cluster1)" --dst "$(get_subnet kind-liqo-cluster2)" -p tcp --dport 6443 -j DROP
+# sudo iptables -I LIQO-cluster2-cluster1 --src "$(get_subnet kind-liqo-cluster2)" --dst "$(get_subnet kind-liqo-cluster1)" -p tcp --dport 6443 -j DROP
+# Restore connectivity
+# sudo iptables -D LIQO-cluster1-cluster2 --src "$(get_subnet kind-liqo-cluster1)" --dst "$(get_subnet kind-liqo-cluster2)" -p tcp --dport 6443 -j DROP
+# sudo iptables -D LIQO-cluster2-cluster1 --src "$(get_subnet kind-liqo-cluster2)" --dst "$(get_subnet kind-liqo-cluster1)" -p tcp --dport 6443 -j DROP
+
+
+# LIQO GATEWAY SERVICE
+# Block connectivity
+# sudo iptables -I LIQO-cluster1-cluster2 --src "$(get_subnet kind-liqo-cluster1)" --dst "$(get_subnet kind-liqo-cluster2)" -p udp --dport 5871 -j DROP
+# sudo iptables -I LIQO-cluster2-cluster1 --src "$(get_subnet kind-liqo-cluster2)" --dst "$(get_subnet kind-liqo-cluster1)" -p udp --dport 5871 -j DROP
+# Restore connectivity
+# sudo iptables -D LIQO-cluster1-cluster2 --src "$(get_subnet kind-liqo-cluster1)" --dst "$(get_subnet kind-liqo-cluster2)" -p udp --dport 5871 -j DROP
+# sudo iptables -D LIQO-cluster2-cluster1 --src "$(get_subnet kind-liqo-cluster2)" --dst "$(get_subnet kind-liqo-cluster1)" -p udp --dport 5871 -j DROP
+
+
+# LIQO AUTH SERVICE
+# Block connectivity
+# sudo iptables -I LIQO-cluster1-cluster2 --src "$(get_subnet kind-liqo-cluster1)" --dst "$(get_subnet kind-liqo-cluster2)" -p tcp --dport 443 -j DROP
+# sudo iptables -I LIQO-cluster2-cluster1 --src "$(get_subnet kind-liqo-cluster2)" --dst "$(get_subnet kind-liqo-cluster1)" -p tcp --dport 443 -j DROP
+# Restore connectivity
+# sudo iptables -D LIQO-cluster1-cluster2 --src "$(get_subnet kind-liqo-cluster1)" --dst "$(get_subnet kind-liqo-cluster2)" -p tcp --dport 443 -j DROP
+# sudo iptables -D LIQO-cluster2-cluster1 --src "$(get_subnet kind-liqo-cluster2)" --dst "$(get_subnet kind-liqo-cluster1)" -p tcp --dport 443 -j DROP
+
+
+
 declare -A cidrs
 keys=()
 


### PR DESCRIPTION
Added FW rules to block specific endpoints exposed between two peered clusters with Kind:
- api server
- liqo-gateway
- liqo-auth 